### PR TITLE
add error handlings

### DIFF
--- a/lib/mackerel-plugin-aws-batch.go
+++ b/lib/mackerel-plugin-aws-batch.go
@@ -61,6 +61,9 @@ func (p AwsBatchPlugin) FetchMetrics() (map[string]interface{}, error) {
 }
 
 func (p *AwsBatchPlugin) prepare() error {
+	if len(p.JobQueues) == 0 {
+		return fmt.Errorf("Missing job queue names")
+	}
 	sess, err := session.NewSession()
 	if err != nil {
 		return err

--- a/lib/mackerel-plugin-aws-batch.go
+++ b/lib/mackerel-plugin-aws-batch.go
@@ -51,9 +51,10 @@ func (p AwsBatchPlugin) FetchMetrics() (map[string]interface{}, error) {
 	for _, name := range p.JobQueues {
 		for _, s := range statuses {
 			n, err := p.getLastPoint(name, s)
-			if err == nil {
-				stat["aws.batch.jobs."+name+"."+s] = n
+			if err != nil {
+				return nil, err
 			}
+			stat["aws.batch.jobs."+name+"."+s] = n
 		}
 	}
 	return stat, nil


### PR DESCRIPTION
This will throw errors in some cases, which currently does not print any messages.
- apparent configuration failure (wrong/missing region, access key, profile, etc…)
- `-job-queue` is empty

Note that wrong job-queue name will be accepted and gets empty values:
```
[github.com/mackerelio/mackerel-plugin-aws-batch]$ AWS_PROFILE=hatena go run main.go -job-queue shibabababababa -region ap-northeast-1
aws.batch.jobs.shibabababababa.SUBMITTED	0.000000	1563329596
aws.batch.jobs.shibabababababa.PENDING	0.000000	1563329596
aws.batch.jobs.shibabababababa.RUNNABLE	0.000000	1563329596
aws.batch.jobs.shibabababababa.STARTING	0.000000	1563329596
aws.batch.jobs.shibabababababa.RUNNING	0.000000	1563329596
aws.batch.jobs.shibabababababa.FAILED	0.000000	1563329596
aws.batch.jobs.shibabababababa.SUCCEEDED	0.000000	1563329596
```